### PR TITLE
Fix looping

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -67,10 +67,13 @@ export default class Audic extends EventTarget<{
 
 			await Promise.all([
 				(async () => {
-					const {repeat} = await vlc.info();
+					const {repeat, loop} = await vlc.info();
 
 					if (repeat) {
 						await vlc.command('pl_repeat');
+					}
+					if (loop) {
+						await vlc.command('pl_loop');
 					}
 				})(),
 				(async () => {
@@ -211,10 +214,13 @@ export default class Audic extends EventTarget<{
 		void (async () => {
 			const vlc = await this._vlc;
 
-			const {repeat} = await vlc.info();
+			const {repeat, loop} = await vlc.info();
 
-			if (value !== repeat) {
+			if (repeat) {
 				await vlc.command('pl_repeat');
+			}
+			if (value !== loop) {
+				await vlc.command('pl_loop');
 			}
 		})();
 	}

--- a/source/index.ts
+++ b/source/index.ts
@@ -216,7 +216,7 @@ export default class Audic extends EventTarget<{
 
 			const {repeat, loop} = await vlc.info();
 
-			if (repeat) {
+			if (value !== repeat) {
 				await vlc.command('pl_repeat');
 			}
 			if (value !== loop) {


### PR DESCRIPTION
This commit leaves only "loop" property, but will likely make it work. see #19
I'm doing this commit directly from github and haven't tested it.

The problem was caused by the fact that VLC have two separate flags: repeat and loop.
See here
https://wiki.videolan.org/VLC_HTTP_requests/

Fixes #19, closes #22